### PR TITLE
update rules so react is always at the top + no unused imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,14 +25,15 @@
     "import/order": [
       "error",
       {
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          "parent",
-          "sibling",
-          "index"
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          }
         ],
+        "pathGroupsExcludedImportTypes": ["builtin"],
         "newlines-between": "always",
         "alphabetize": {
           "order": "asc",

--- a/src/components/chat/chatHeader.tsx
+++ b/src/components/chat/chatHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import Image from 'next/image';
 
 import Logo from '/public/media/policy-wonk.png';

--- a/src/components/chat/main.tsx
+++ b/src/components/chat/main.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import React from 'react';
+
 import { useChat, Message } from 'ai/react';
 import { useRouter } from 'next/navigation';
-import React from 'react';
 
 import { getChatMessages } from '@/services/chatService';
 

--- a/src/components/chat/markdown.tsx
+++ b/src/components/chat/markdown.tsx
@@ -1,4 +1,5 @@
 import { FC, memo } from 'react';
+
 import ReactMarkdown, { Options } from 'react-markdown';
 
 export const MemoizedReactMarkdown: FC<Options> = memo(

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,6 @@
-import Image from 'next/image';
 import React from 'react';
+
+import Image from 'next/image';
 
 import Logo from '/public/media/ucdavis-grey.svg';
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import Link from 'next/link';
 import { Session } from 'next-auth';
-import React from 'react';
 
 import { auth } from '@/auth';
 import SidebarLinks from '@/components/layout/sidebarLinks';

--- a/src/components/layout/sidebarLinks.tsx
+++ b/src/components/layout/sidebarLinks.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Link from 'next/link';
 import React from 'react';
+
+import Link from 'next/link';
 
 const SidebarLinks: React.FC = () => {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "noUnusedLocals": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted ESLint configuration to better organize import orders, specifically handling "react" related imports.
	- Reorganized import statements across various components (`ChatHeader`, `Main`, `Markdown`, `Footer`, `Sidebar`, `SidebarLinks`) for consistency and adherence to the updated ESLint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->