### PR TITLE
update the prompt and play with footnotes

### DIFF
--- a/src/components/chat/chatMessage.tsx
+++ b/src/components/chat/chatMessage.tsx
@@ -13,9 +13,14 @@ export function ChatMessage({ message }: ChatMessageProps) {
       <MemoizedReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          a: ({ node, ...props }) => (
-            <a {...props} target='_blank' rel='noopener noreferrer' />
-          ),
+          a: ({ node, ...props }) => {
+            // open links in new tab but not for internal links
+            if (props.href?.startsWith('http')) {
+              return <a {...props} target='_blank' rel='noopener noreferrer' />;
+            } else {
+              return <a {...props} />;
+            }
+          },
         }}
       >
         {message.content}

--- a/src/components/chat/chatMessage.tsx
+++ b/src/components/chat/chatMessage.tsx
@@ -1,4 +1,5 @@
 import { Message } from 'ai';
+import Link from 'next/link';
 import remarkGfm from 'remark-gfm';
 
 import { MemoizedReactMarkdown } from './markdown';
@@ -18,7 +19,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
             if (props.href?.startsWith('http')) {
               return <a {...props} target='_blank' rel='noopener noreferrer' />;
             } else {
-              return <a {...props} />;
+              return <Link {...props} href={props.href || '#'} />;
             }
           },
         }}


### PR DESCRIPTION
playing with individual footnotes, I think i like this better.  chatGPT3.5 is even pretty good at it, but it sometimes messes up the footer formatting.  Could be fixed either by using 4-turbo or w/ some manual cleanup of the content later. 

Eventually I'd like to pull in line numbers for the sources and each footnote can open just the relevant section of the policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the chat messaging system to open external links in new tabs, enhancing navigation safety.
	- Enhanced the display formatting of search results in chat to provide clearer information.

- **Bug Fixes**
	- Improved system messages in chat for better clarity and user guidance based on search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->