### PR TITLE
scope to just our current corpus

### DIFF
--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -43,6 +43,15 @@ export const getSearchResults = async (
 ) => {
   const searchResultMaxSize = 5;
 
+  // scopes for our "all" search
+  const allowedScopes = [
+    'ucop',
+    'ucdppm',
+    'ucdppsm',
+    'ucddelegation',
+    'ucdinterim',
+  ];
+
   // TODO: augment search w/ keyword search, or perhaps follow up questions?
   // get our search results
   const searchResults = await searchClient.search<PolicyIndex>({
@@ -54,9 +63,17 @@ export const getSearchResults = async (
         query_vector: embeddings.data[0].embedding, // the query vector
         k: searchResultMaxSize,
         num_candidates: 200,
+        filter: {
+          // pre-filter before knn
+          terms: {
+            'metadata.scope.keyword': allowedScopes,
+          },
+        },
       },
     },
   });
+
+  // Note: if we want >1 fileter, we can add a bool -> must -> terms[]
 
   return searchResults;
 };


### PR DESCRIPTION
filter to just scopes we want -- this way we can add in the contracts w/o messing up results.  Later we'll need to tune based on filter feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chat search functionality to filter results based on predefined scopes, improving the relevance of search results for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->