### PR TITLE
GTM

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <head>
-        <GoogleTagManager gtmId='G-M1SEC6TR1S' />
+        <GoogleTagManager gtmId='GTM-NNCH6SSL' />
 
         <link rel='image_src' href='/media/thumbnail.jpg' />
         <link

--- a/src/components/chat/answer/chatActions.tsx
+++ b/src/components/chat/answer/chatActions.tsx
@@ -7,7 +7,7 @@ import { usePathname } from 'next/navigation';
 import FeedbackBar from '@/components/chat/answer/feedbackBar';
 import CopyToClipboardButton from '@/components/ui/copyToClipboardButton';
 import { AI } from '@/lib/actions';
-import gtagEvent from '@/lib/gtag';
+import { gtagEvent, GTagEvents } from '@/lib/gtag';
 import { Feedback } from '@/models/chat';
 import { saveReaction } from '@/services/historyService';
 
@@ -39,14 +39,7 @@ const ChatActions: React.FC<ChatActionsProps> = ({
     }
     setFeedbackSent(feedback);
 
-    gtagEvent({
-      event: 'feedback',
-      feedback,
-    });
-
-    gtagEvent({
-      event: `feedback_${feedback}`,
-    });
+    gtagEvent({ event: GTagEvents.FEEDBACK, chat: aiState });
 
     await saveReaction(chatId, feedback);
   };
@@ -56,7 +49,7 @@ const ChatActions: React.FC<ChatActionsProps> = ({
       <div className='row mb-3'>
         <div className='col-1'>{/* empty */}</div>
         <div className='col-11'>
-          <CopyToClipboardButton id={chatId} value={content} />
+          <CopyToClipboardButton id='gtag-copy-chat' value={content} />
           {!onSharedPage && (
             <>
               <FeedbackButtons

--- a/src/components/chat/answer/shareModal.tsx
+++ b/src/components/chat/answer/shareModal.tsx
@@ -9,6 +9,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 
 import AnimatedButton from '@/components/ui/animatedButton';
 import { AI } from '@/lib/actions';
+import { gtagEvent, GTagEvents } from '@/lib/gtag';
 
 import { ShareButton } from './shareButtons';
 import SharedUrl from './sharedUrl';
@@ -26,6 +27,7 @@ const ShareModal: React.FC = () => {
 
   const handleShare = async () => {
     setIsLoading('share');
+    gtagEvent({ event: GTagEvents.SHARE, chat: aiState });
     await shareChat(chatId);
     setIsLoading('');
   };

--- a/src/components/chat/answer/shareModal.tsx
+++ b/src/components/chat/answer/shareModal.tsx
@@ -34,12 +34,14 @@ const ShareModal: React.FC = () => {
 
   const handleRegenShare = async () => {
     setIsLoading('regen');
+    gtagEvent({ event: GTagEvents.REGEN_SHARE, chat: aiState });
     await shareChat(chatId);
     setIsLoading('');
   };
 
   const handleUnshare = async () => {
     setIsLoading('unshare');
+    gtagEvent({ event: GTagEvents.UNSHARE, chat: aiState });
     await unshareChat(chatId);
     setIsLoading('');
   };

--- a/src/components/chat/answer/sharedUrl.tsx
+++ b/src/components/chat/answer/sharedUrl.tsx
@@ -57,7 +57,7 @@ const SharedUrl: React.FC<SharedUrlProps> = ({
               readOnly={true}
             />
             <div className='ms-2'>
-              <CopyToClipboardButton value={url} id='share-copy-url' />
+              <CopyToClipboardButton value={url} id='gtag-copy-share-url' />
               <RegenerateShareButton
                 handleShare={handleRegenShare}
                 loadingState={isLoading}

--- a/src/components/chat/answer/wonkMessage.tsx
+++ b/src/components/chat/answer/wonkMessage.tsx
@@ -39,7 +39,7 @@ export const WonkMessage = ({
       <div className='col-3 col-md-1 mb-2'>
         <WonkPortrait isLoading={isLoading} />
       </div>
-      <div className='col-10 col-md-11'>
+      <div className='col-10 col-md-11 gtag'>
         <p className='chat-name'>
           <strong>Policy Wonk</strong>
         </p>

--- a/src/components/chat/ask/chatInput.tsx
+++ b/src/components/chat/ask/chatInput.tsx
@@ -5,7 +5,7 @@ import { useUIState, useActions } from 'ai/rsc';
 import { nanoid } from 'nanoid';
 
 import { AI, Actions } from '@/lib/actions';
-import gtagEvent from '@/lib/gtag';
+import { gtagEvent, GTagEvents } from '@/lib/gtag';
 import { focuses } from '@/models/focus';
 
 import FocusBanner from '../answer/focusBanner';
@@ -43,11 +43,8 @@ const ChatInput = () => {
 
     const responseMessage = await submitUserMessage(question, focus);
 
-    gtagEvent({
-      event: 'chat',
-      focus: focus.name,
-      subFocus: focus.subFocus,
-    });
+    // TODO: use full AI state
+    gtagEvent({ event: GTagEvents.NEW_CHAT });
 
     setMessagesUI((currentMessages) => [...currentMessages, responseMessage]);
   };

--- a/src/components/chat/ask/defaultQuestions.tsx
+++ b/src/components/chat/ask/defaultQuestions.tsx
@@ -18,6 +18,7 @@ const DefaultQuestions: React.FC<DefaultQuestionsProps> = ({
     <div className='d-grid d-md-block'>
       {questions.map((question, index) => (
         <button
+          id={`gtag-default-question-${question}`}
           key={index}
           className='btn btn-wonk text-start color-secondary-font'
           onClick={() => onQuestionSubmit(question)}

--- a/src/lib/gtag.tsx
+++ b/src/lib/gtag.tsx
@@ -2,31 +2,48 @@
 
 import { sendGTMEvent } from '@next/third-parties/google';
 
-import { Feedback } from '@/models/chat';
+import { ChatHistory, Feedback } from '@/models/chat';
 
-export interface GTagFeedback {
-  event: 'feedback';
-  feedback: Feedback;
+/* the properties here should use snake_case and exactly match what is set up in GTM */
+export enum GTagEvents {
+  // custom events (manually triggered using gtagEvent()
+  FEEDBACK = 'feedback',
+  SHARE = 'share',
+  NEW_CHAT = 'new_chat',
+
+  /*
+  // automatic events (triggered by user actions), e.g. page visit or button click 
+  // Q: do we want any of these to be custom events, so we can pass along more data?
+  // e.g. see if chat contents are copied from /chat/ or from /share/
+  // or see what default question was clicked
+  COPY_CHAT = 'copy_chat', // automatically triggered on click from id=gtag=copy-chat*
+  COPY_SHARE = 'copy_share', // automatically triggered on click from id=gtag=copy-share-url*
+  DEFAULT_QUESTION = 'default_question', // automatically triggered on click from id=gtag-default-question*
+  ABOUT_PAGE = 'about_page', // automatically triggered on visit to /about
+  SHARED_PAGE_VIEW = 'shared_page_view', // automatically triggered on visit to /share/*
+  CITATION_CLICKED = 'citation_clicked', // automatically triggered on click from div.gtag a selector inside wonkMessage
+  */
 }
 
-export interface GTagFeedbackPositive {
-  event: 'feedback_thumbs_up';
+interface GTagEventVariables {
+  event: GTagEvents;
+  feedback?: Feedback;
+  focus?: string;
+  sub_focus?: string;
 }
 
-export interface GTagFeedbackNegative {
-  event: 'feedback_thumbs_down';
+interface gtagEventProps {
+  event: GTagEvents;
+  chat?: ChatHistory;
 }
+/* takes in the name of the event and the full AI state, and then extracts the variables we have set up in GTM */
+export const gtagEvent = ({ event, chat }: gtagEventProps): void => {
+  const eventObj: GTagEventVariables = {
+    event,
+    focus: chat?.focus?.name,
+    sub_focus: chat?.focus?.subFocus,
+    feedback: chat?.reaction,
+  };
 
-export interface GTagChat {
-  event: 'chat';
-  focus: string;
-  subFocus?: string;
-}
-
-const gtagEvent = (
-  event: GTagChat | GTagFeedback | GTagFeedbackPositive | GTagFeedbackNegative
-) => {
-  sendGTMEvent(event);
+  sendGTMEvent(eventObj);
 };
-
-export default gtagEvent;

--- a/src/lib/gtag.tsx
+++ b/src/lib/gtag.tsx
@@ -9,6 +9,8 @@ export enum GTagEvents {
   // custom events (manually triggered using gtagEvent()
   FEEDBACK = 'feedback',
   SHARE = 'share',
+  UNSHARE = 'unshare',
+  REGEN_SHARE = 'regen_share',
   NEW_CHAT = 'new_chat',
 
   /*


### PR DESCRIPTION
please see [GTM on Notion](https://www.notion.so/Google-Tag-Manager-Google-Analytics-b0bac39a50e2467a81c1883eeaf6bf9b?pvs=4)

sets up custom GTM gtag events for: 
* feedback
* new chat 
* chat shared

plus all these events within Google Tag Manager
![image](https://github.com/ucdavis/PolicyWonk/assets/27025973/45069dd0-772f-4729-a9e5-c5531497064b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event tracking with Google Tag Manager across various components.
  
- **Improvements**
  - Updated event handling logic to use structured input objects for better event management.
  - Added dynamic `id` attributes to buttons in the `DefaultQuestions` component for improved tracking.
  
- **Bug Fixes**
  - Corrected `id` attributes in `CopyToClipboardButton` components to ensure accurate event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->