### PR TITLE
allow focus selection in url, and retain focus on new chats

### DIFF
--- a/src/app/chat/[chatid]/page.tsx
+++ b/src/app/chat/[chatid]/page.tsx
@@ -18,9 +18,15 @@ type HomePageProps = {
   params: {
     chatid: string;
   };
+  searchParams: {
+    focus?: string;
+  };
 };
 // TODO: loading animation when chatId changes
-const ChatPage = async ({ params: { chatid } }: HomePageProps) => {
+const ChatPage = async ({
+  params: { chatid },
+  searchParams: { focus },
+}: HomePageProps) => {
   const session = (await auth()) as Session;
 
   // middleware should take care of this, but if it doesn't then redirect to login
@@ -31,7 +37,7 @@ const ChatPage = async ({ params: { chatid } }: HomePageProps) => {
   const chat: ChatHistory | null =
     chatid !== 'new'
       ? await getChat(chatid, session.user.id)
-      : newChatSession(session);
+      : newChatSession(session, focus);
 
   // if getChat returns null
   // will happen if the user is at an /chat/{id} that is not /chat/new
@@ -54,12 +60,21 @@ const ChatPage = async ({ params: { chatid } }: HomePageProps) => {
 export default ChatPage;
 
 // TODO: move this into a server-only file
-const newChatSession = (session: Session) => {
+const newChatSession = (session: Session, focusParam?: string) => {
+  let focus = focuses[0];
+
+  if (focusParam) {
+    const foundFocus = focuses.find((f) => f.name === focusParam);
+    if (foundFocus) {
+      focus = foundFocus;
+    }
+  }
+
   const chat: ChatHistory = {
     id: nanoid(),
     title: 'Unknown Title',
     messages: [],
-    focus: focuses[0],
+    focus: focus,
     llmModel: llmModel,
     user: session.user?.name ?? 'Unknown User',
     userId: session.user?.id ?? 'Unknown User',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,27 @@ import React from 'react';
 
 import { redirect } from 'next/navigation';
 
-const RedirectComponent: React.FC = () => {
-  redirect('/chat/new');
+interface RedirectComponentProps {
+  searchParams: { [key: string]: string | string[] };
+}
+
+const RedirectComponent: React.FC<RedirectComponentProps> = ({
+  searchParams,
+}) => {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (Array.isArray(value)) {
+      value.forEach((val) => params.append(key, val));
+    } else {
+      params.append(key, value);
+    }
+  }
+
+  const destination = `/chat/new?${params.toString()}`;
+  redirect(destination);
+
+  return null; // this component will never render
 };
 
 export default RedirectComponent;

--- a/src/components/chat/ask/chatInput.tsx
+++ b/src/components/chat/ask/chatInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 
-import { useUIState, useActions } from 'ai/rsc';
+import { useUIState, useActions, useAIState } from 'ai/rsc';
 import { nanoid } from 'nanoid';
 
 import { AI } from '@/lib/actions';
@@ -18,9 +18,10 @@ import FocusBar from './focusBar';
 // Container for all of components that can be used to send messages to the chat
 // Will send the actual message to the chatAI system
 const ChatInput = () => {
-  const [focus, setFocus] = React.useState(focuses[0]);
-
+  const [aiState] = useAIState<typeof AI>();
   const [_, setMessagesUI] = useUIState<typeof AI>();
+
+  const [focus, setFocus] = React.useState(aiState.focus);
 
   // instead of passing in a submit function, we use a server action defined in actions.tsx when we create the AI
   // as Actions maybe a little hack but it lets us strongly type the actions

--- a/src/components/chat/main.tsx
+++ b/src/components/chat/main.tsx
@@ -35,7 +35,13 @@ const MainContent = () => {
   }, [aiState.messages, router, aiState.id, pathname]);
 
   const onNewMessage = () => {
-    router.push('/');
+    let newRoute = `/?focus=${aiState.focus.name}`;
+
+    if (aiState.focus.subFocus) {
+      newRoute += `&subFocus=${aiState.focus.subFocus}`;
+    }
+
+    router.push(newRoute);
   };
 
   return (

--- a/src/models/focus.ts
+++ b/src/models/focus.ts
@@ -65,3 +65,37 @@ export const unions: Union[] = [
   { key: 'f3', value: 'Local 4920' },
   { key: 'm3', value: 'Medical Residents' },
 ];
+
+// get a focus w/ sub-focus if it exists, otherwise return undefined
+export const getFocusWithSubFocus = (
+  focus?: string,
+  subFocus?: string
+): Focus | undefined => {
+  const foundFocus = focuses.find((f) => f.name === focus);
+
+  if (!foundFocus) {
+    return;
+  }
+
+  // right now, we only have unions as a focus with sub-focus
+  if (foundFocus.name === 'unions') {
+    // find the union by key
+    const union = unions.find((u) => u.key === subFocus);
+
+    // if we found the union, we can return the focus with the union name as the subFocus
+    if (union) {
+      return {
+        ...foundFocus,
+        subFocus: union.value,
+        description: getUnionDescription(union),
+      };
+    }
+  } else {
+    // if the focus doesn't have a sub-focus, we can just return the focus
+    return foundFocus;
+  }
+};
+
+export const getUnionDescription = (union: Union): string => {
+  return union ? `${union.value} (${union.key})` : '';
+};


### PR DESCRIPTION
Basic ideas is url search params for focus and subFocus which are read and used to set the AIState to the proper default focus.  Turned out to be a little tricky because the AIState wasn't actually being used and also because when you chat and click ask a new question, we need to route back through home `/` in order to trigger a new query, so I need to preserve any query vars.  

Closes #62 and closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced chat session initialization with new focus and sub-focus parameters.
  - Added AI state management to dynamically update chat focus.

- **Improvements**
  - Updated redirection logic to construct URLs based on search parameters.
  - Improved route navigation based on AI state properties.

- **Bug Fixes**
  - Fixed issues with chat focus handling and state updates.

- **Code Enhancements**
  - Introduced utility functions for handling focus with sub-focus logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->