### PR TITLE
transform the way we are handling citations

### DIFF
--- a/src/components/chat/answer/wonkMessage.tsx
+++ b/src/components/chat/answer/wonkMessage.tsx
@@ -69,38 +69,15 @@ export const WonkMessage = ({
   );
 };
 
-const cleanBracketedExpression = (str: string) => {
-  return str.replace(/\[\^([^\]]+)\]/g, (fullMatch, innerContent) => {
-    // Remove all non-word characters (except digits and underscore) and spaces from the innerContent
-    const cleanedContent = innerContent.replace(/[\W_]+/g, '');
-    return '[^' + cleanedContent + ']';
-  });
-};
-
-const cleanBadCitationList = (str: string) => {
-  // sometimes the llm lists citations w/ `- [^APM 015]` and we need to dump the `- `
-  return str.replace(/- \[\^([^\]]+)\]/g, '[^$1]');
-};
-
-const reformatFootnotes = (markdown: string) => {
-  // Regular expression to match a footnote pattern [^doc2]: with optional leading whitespaces or newlines
-  const footnotePattern = /(?:\s*\n)?(\[\^\w+\]:\s*\[.*?\])/g;
-
-  // Replace function to ensure each footnote starts on a new line
-  const formattedMarkdown = markdown.replace(
-    footnotePattern,
-    (match) => `\n${match.trim()}`
-  );
-
-  // Trim any leading or trailing whitespace (to clear any excessive newlines at the start)
-  return formattedMarkdown.trim();
+const stripTemporaryCitations = (content: string) => {
+  // temporary citations are of the form <c:1234>
+  // we want to strip these out
+  return content.replace(/<c:\d+>/g, '');
 };
 
 // fix up common markdown issues
 const sanitizeMarkdown = (content: string) => {
-  content = cleanBracketedExpression(content);
-  content = cleanBadCitationList(content);
-  content = reformatFootnotes(content);
+  content = stripTemporaryCitations(content);
 
   return content;
 };

--- a/src/components/chat/answer/wonkMessage.tsx
+++ b/src/components/chat/answer/wonkMessage.tsx
@@ -49,7 +49,7 @@ export const WonkMessage = ({
               remarkPlugins={[remarkGfm]}
               components={{
                 a: ({ node, ...props }) => {
-                  // open links in new tab but not for internal links
+                  // external links should open in a new tab
                   if (props.href?.startsWith('http')) {
                     return (
                       <a
@@ -63,7 +63,28 @@ export const WonkMessage = ({
                         rel='noopener noreferrer'
                       />
                     );
-                  } else {
+                  }
+                  // internal links might be footnotes and we want to handle them differently
+                  else if (props.href?.startsWith('#')) {
+                    const footnoteRef = Object.keys(props).find(
+                      (key) => key === 'data-footnote-ref'
+                    );
+
+                    if (footnoteRef) {
+                      // for footnote references, we want to show them in a superscript
+                      return <sup>{props.children}</sup>;
+                    }
+
+                    const footnoteBackRef = Object.keys(props).find(
+                      (key) => key === 'data-footnote-backref'
+                    );
+
+                    if (footnoteBackRef) {
+                      // don't render the backref
+                      return null;
+                    }
+
+                    // other internal links should be handled by next/link
                     return (
                       <Link
                         onClick={() => {
@@ -75,6 +96,9 @@ export const WonkMessage = ({
                         href={props.href || '#'}
                       />
                     );
+                  } else {
+                    // regular links (like mailto:)
+                    return <a {...props} />;
                   }
                 },
               }}
@@ -93,7 +117,7 @@ export const WonkMessage = ({
 
 const stripTemporaryCitations = (content: string) => {
   // temporary citations are of the form <c:1234>
-  // we want to strip these out
+  // we want to strip these out so they aren't shown
   return content.replace(/<c:\d+>/g, '');
 };
 

--- a/src/lib/actions.tsx
+++ b/src/lib/actions.tsx
@@ -20,6 +20,7 @@ import {
   expandedTransformSearchResults,
   openai,
   llmModel,
+  transformContentWithCitations,
 } from '@/services/chatService';
 import {
   removeShareChat,
@@ -120,15 +121,23 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
       text: ({ content, done, delta }) => {
         if (done) {
           textStream.done();
+
+          // once we are finished, we need to modify the content to transform the citations
+          const finalContent = transformContentWithCitations(
+            content,
+            searchResults
+          );
+
           const finalNode = (
             <WonkMessage
               chatId={chatId}
               key={wonkMsgId}
-              content={content}
+              content={finalContent}
               isLoading={false}
               wonkThoughts={''}
             />
           );
+
           // finally, close out the initial UI stream with the final node
           chatWindowUI.done(finalNode);
           // and update the AI state with the final message
@@ -140,7 +149,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
               {
                 id: wonkMsgId,
                 role: 'assistant',
-                content,
+                content: finalContent,
               },
             ],
           });

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -25,6 +25,8 @@ export type UIStateNode = {
 export type UIState = UIStateNode[];
 
 export type PolicyIndex = {
+  id: string;
+  docNumber: number;
   text: string;
   metadata: PolicyMetadata;
   vector: number[];


### PR DESCRIPTION
instead of instructing the llm to generate markdown, which is pretty error-prone, we instead just use a simple <c:1> format to identify our documents and then read the final text output and transform those into markdown citations with a proper footnotes section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved markdown processing in chat messages by consolidating cleaning functions into a single, more efficient function.
  - Enhanced content transformation with citations before rendering in the UI.

- **Refactor**
  - Simplified and refactored the transformation of search results and content processing functions for better performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->