### PR TITLE
Rh/update ai pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@next/third-parties": "^14.2.3",
         "@ucdavis/gunrockin": "^1.1.3",
-        "ai": "^3.0.13",
+        "ai": "^3.1.33",
         "bootstrap": "^5.3.3",
         "framer-motion": "^11.1.1",
         "mongodb": "^6.5.0",
@@ -53,6 +53,150 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.10.tgz",
+      "integrity": "sha512-NzkrtREQpHID1cTqY/C4CI30PVOaXWKYytDR2EcytmFgnP7Z6+CrGIA/YCnNhYAuUm6Nx+nGpRL/Hmyrv7NYzg==",
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-0.0.13.tgz",
+      "integrity": "sha512-cB2dPm9flj+yin5sjBLFcXdW8sZtAXLE/OLKgz9uHpHM55s7mnwZrDGfO6ot/ukHTxDDJunZLW7qSjgK/u0F1g==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.10",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-0.0.1.tgz",
+      "integrity": "sha512-y6KXzxRR7vmAgDVnS/hnLPt3RztvWOisANBw47O1o1D2nDeUqTo8E/SNw2J8mzzlRInGaw40EREY8jEf9AcwWQ==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "0.0.13",
+        "@ai-sdk/ui-utils": "0.0.1",
+        "swr": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/solid": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.1.tgz",
+      "integrity": "sha512-5WWdoqpemYW66rMZUYF4sbDtZfF96Vt8RtrzpLv+95ZUM1nY1elxAWpHCeOyYEjWJE5+eiKpUs6Jr5mP2/gz8Q==",
+      "dependencies": {
+        "@ai-sdk/ui-utils": "0.0.1",
+        "solid-swr-store": "0.10.7",
+        "swr-store": "0.10.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.7.7"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/svelte": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.1.tgz",
+      "integrity": "sha512-bpjTLKOwdcXjJzboq15etT1hdnRI1ErPZweWSsu1/LJlEFzD1M0qpZQwWHwPquYkzeppXOgsLrUZ+9D2RoC47Q==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "0.0.13",
+        "@ai-sdk/ui-utils": "0.0.1",
+        "sswr": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.1.tgz",
+      "integrity": "sha512-zOr1zIw/EH4fEQvDKsqYG3wY7GW32h8Wrx0lQpSAP59UCA4zgHBH6ogF5oj7+LUuWjT6be9S0G3l/tEPyRyxEw==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "0.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/vue": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-0.0.1.tgz",
+      "integrity": "sha512-B3qAW22FYGy1ltobnF7LiPAmARTrCkH15qjw4WAXCnvRohsYOFTDACOBEsXRfa1OHmqWsUOYeNtE/oPhK3ybqw==",
+      "dependencies": {
+        "@ai-sdk/ui-utils": "0.0.1",
+        "swrv": "1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -99,9 +243,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "peer": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -930,16 +1074,16 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
-      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/shared": "3.4.27",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
@@ -949,30 +1093,30 @@
       "peer": true
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
-      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-core": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
-      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.21",
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/compiler-core": "3.4.27",
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.7",
-        "postcss": "^8.4.35",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
@@ -1028,62 +1172,62 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
-      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
-      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+      "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.4.21"
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
-      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+      "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/reactivity": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
-      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+      "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
       "peer": true,
       "dependencies": {
-        "@vue/runtime-core": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@vue/runtime-core": "3.4.27",
+        "@vue/shared": "3.4.27",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
-      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+      "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
-        "vue": "3.4.21"
+        "vue": "3.4.27"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
-      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
       "peer": true
     },
     "node_modules/abort-controller": {
@@ -1129,41 +1273,42 @@
       }
     },
     "node_modules/ai": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-3.0.13.tgz",
-      "integrity": "sha512-fDrYnVTdMJuS/qYUq0T/CX3WDuTfcZFie9LkgnoQ2layfUG2Wzh/mpfkfYXFEq/mqnpep3xUtECOB1weyyvwUg==",
+      "version": "3.1.33",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-3.1.33.tgz",
+      "integrity": "sha512-JXiWKvkfRFhzUgqqVRByhovP8BOsv0LdA92lEtwm4opxM7EsKqSvCz3Yb5abp4GRUz7NS3ukBbGCjvRlymgQIw==",
       "dependencies": {
-        "eventsource-parser": "1.0.0",
-        "jsondiffpatch": "^0.6.0",
+        "@ai-sdk/provider": "0.0.10",
+        "@ai-sdk/provider-utils": "0.0.13",
+        "@ai-sdk/react": "0.0.1",
+        "@ai-sdk/solid": "0.0.1",
+        "@ai-sdk/svelte": "0.0.1",
+        "@ai-sdk/ui-utils": "0.0.1",
+        "@ai-sdk/vue": "0.0.1",
+        "eventsource-parser": "1.1.2",
+        "json-schema": "0.4.0",
+        "jsondiffpatch": "0.6.0",
         "nanoid": "3.3.6",
-        "solid-swr-store": "0.10.7",
-        "sswr": "2.0.0",
-        "swr": "2.2.0",
-        "swr-store": "0.10.6",
-        "swrv": "1.0.4",
-        "zod-to-json-schema": "^3.22.4"
+        "secure-json-parse": "2.7.0",
+        "sswr": "2.1.0",
+        "zod-to-json-schema": "3.22.5"
       },
       "engines": {
-        "node": ">=14.6"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18.2.0",
-        "solid-js": "^1.7.7",
+        "openai": "^4.42.0",
+        "react": "^18 || ^19",
         "svelte": "^3.0.0 || ^4.0.0",
-        "vue": "^3.3.4",
         "zod": "^3.0.0"
       },
       "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
-        "solid-js": {
-          "optional": true
-        },
         "svelte": {
-          "optional": true
-        },
-        "vue": {
           "optional": true
         },
         "zod": {
@@ -1498,11 +1643,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1682,14 +1822,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1813,14 +1945,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/css-tree": {
@@ -1998,15 +2122,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
-      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2744,9 +2859,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.0.0.tgz",
-      "integrity": "sha512-9jgfSCa3dmEme2ES3mPByGXfgZ87VbP97tng1G2nWwWx6bV2nYxm2AWCrbQjXToSe+yYlqaZNtxffR9IeQr95g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
       "engines": {
         "node": ">=14.18"
       }
@@ -3511,11 +3626,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -3924,6 +4034,11 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4087,15 +4202,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.8",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/markdown-table": {
@@ -4105,16 +4217,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -5366,15 +5468,14 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.29.2.tgz",
-      "integrity": "sha512-cPkT6zjEcE4qU5OW/SoDDuXEsdOLrXlAORhzmaguj5xZSPlgKvLhi27sFWhLKj07Y6WKNWxcwIbzm512FzTBNQ==",
+      "version": "4.50.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.50.0.tgz",
+      "integrity": "sha512-2ADkNIU6Q589oYHr5pn9k7SbUcrBTK9X0rIXrYqwMVSoqOj1yK9/1OO0ExaWsqOOpD7o58UmRjeKlx9gKAcuKQ==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
         "abort-controller": "^3.0.0",
         "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7",
@@ -6140,18 +6241,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.0.5.tgz",
-      "integrity": "sha512-TM+Z11tHHvQVQKeNlOUonOWnsNM+2IBwZ4vwoi4j3zKzIpc5IDw8WPwCfcc8F17wy6cBcJGbZbFOR0UCuTZHQA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.0.7.tgz",
+      "integrity": "sha512-n6ZMQX5q0Vn19Zq7CIKNIo7E75gPkGCFUEqDpa8jgwpYr/vScjqnQ6H09t1uIiZ0ZSK0ypEGvrYK2bhBGWsGdw==",
       "peer": true,
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.0.5.tgz",
-      "integrity": "sha512-8+pDC1vOedPXjKG7oz8o+iiHrtF2WswaMQJ7CKFpccvSYfrzmvKY9zOJWCg+881722wIHfwkdnRmiiDm9ym+zQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.0.7.tgz",
+      "integrity": "sha512-GO7TkWvodGp6buMEX9p7tNyIkbwlyuAWbI6G9Ec5bhcm7mQdu3JOK1IXbEUwb3FVzSc363GraG/wLW23NSavIw==",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -6253,9 +6354,9 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.16.tgz",
-      "integrity": "sha512-rja94MNU9flF3qQRLNsu60QHKBDKBkVE1DldJZPIfn2ypIn3NV2WpSbGTQIvsyGPBo+9E2IMjwqnqpbgfWuzeg==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.17.tgz",
+      "integrity": "sha512-E0FkUgv9sG/gEBWkHr/2XkBluHb1fkrHywUgA6o6XolPDCJ4g1HaLmQufcBBhiF36ee40q+HpG/vCZu7fLpI3Q==",
       "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
@@ -6301,14 +6402,14 @@
       }
     },
     "node_modules/sswr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sswr/-/sswr-2.0.0.tgz",
-      "integrity": "sha512-mV0kkeBHcjcb0M5NqKtKVg/uTIYNlIIniyDfSGrSfxpEdM9C365jK0z55pl9K0xAkNTJi2OAOVFQpgMPUk+V0w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sswr/-/sswr-2.1.0.tgz",
+      "integrity": "sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==",
       "dependencies": {
         "swrev": "^4.0.0"
       },
       "peerDependencies": {
-        "svelte": "^4.0.0"
+        "svelte": "^4.0.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/streamsearch": {
@@ -6564,9 +6665,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.12.tgz",
-      "integrity": "sha512-d8+wsh5TfPwqVzbm4/HCXC783/KPHV60NvwitJnyTA5lWn1elhXMNWhXGCJ7PwPa8qFUnyJNIyuIRt2mT0WMug==",
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
+      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
@@ -6977,9 +7078,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -7012,16 +7113,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
-      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+      "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-sfc": "3.4.21",
-        "@vue/runtime-dom": "3.4.21",
-        "@vue/server-renderer": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-sfc": "3.4.27",
+        "@vue/runtime-dom": "3.4.27",
+        "@vue/server-renderer": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -7275,18 +7376,18 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.4.tgz",
-      "integrity": "sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.22.5.tgz",
+      "integrity": "sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==",
       "peerDependencies": {
         "zod": "^3.22.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "policywonk",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/openai": "^0.0.29",
         "@elastic/elasticsearch": "^8.12.2",
         "@fortawesome/free-brands-svg-icons": "^6.5.1",
         "@fortawesome/free-regular-svg-icons": "^6.5.1",
@@ -22,7 +23,6 @@
         "nanoid": "^5.0.6",
         "next": "14.1.3",
         "next-auth": "^5.0.0-beta.16",
-        "openai": "^4.29.2",
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^9.0.1",
@@ -53,6 +53,60 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-0.0.29.tgz",
+      "integrity": "sha512-LctoOAlOX7bI3dQ5IA9DXBmHhhb2l59pg+aFclIp0qR86bqrB7eEH/odu8wn+yWjPy90D40aU0E1sNDYz985vA==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.10",
+        "@ai-sdk/provider-utils": "0.0.14"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-0.0.14.tgz",
+      "integrity": "sha512-PCQFN3MlC6DShS/81IFU9NVvt9OekQGiZTEowRc2AwAwWrDsv7er3UkcMswFAL/Z7xZKjgu0dZTNH1z9oUlo7A==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.10",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -876,6 +930,7 @@
       "version": "20.11.28",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
       "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -884,6 +939,8 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
       "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -1234,6 +1291,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -1265,6 +1324,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -1593,7 +1654,9 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -1903,6 +1966,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2094,6 +2159,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2854,6 +2921,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3021,6 +3090,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3033,12 +3104,16 @@
     "node_modules/form-data-encoder": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.3"
@@ -3051,6 +3126,8 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -3454,6 +3531,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -5057,6 +5136,8 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5065,6 +5146,8 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5300,6 +5383,8 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -5308,6 +5393,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5471,6 +5558,8 @@
       "version": "4.50.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.50.0.tgz",
       "integrity": "sha512-2ADkNIU6Q589oYHr5pn9k7SbUcrBTK9X0rIXrYqwMVSoqOj1yK9/1OO0ExaWsqOOpD7o58UmRjeKlx9gKAcuKQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -5489,6 +5578,8 @@
       "version": "18.19.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
       "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6784,7 +6875,9 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -6972,7 +7065,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "devOptional": true
     },
     "node_modules/unified": {
       "version": "11.0.4",
@@ -7145,6 +7239,8 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -7152,12 +7248,16 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@next/third-parties": "^14.2.3",
     "@ucdavis/gunrockin": "^1.1.3",
-    "ai": "^3.0.13",
+    "ai": "^3.1.33",
     "bootstrap": "^5.3.3",
     "framer-motion": "^11.1.1",
     "mongodb": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "next lint --fix && prettier --write \"src/**/*.{js,jsx,ts,tsx}\""
   },
   "dependencies": {
+    "@ai-sdk/openai": "^0.0.29",
     "@elastic/elasticsearch": "^8.12.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
@@ -26,7 +27,6 @@
     "nanoid": "^5.0.6",
     "next": "14.1.3",
     "next-auth": "^5.0.0-beta.16",
-    "openai": "^4.29.2",
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^9.0.1",

--- a/src/app/chat/[chatid]/page.tsx
+++ b/src/app/chat/[chatid]/page.tsx
@@ -1,17 +1,15 @@
 'use server'; // since this is an async component
 import React from 'react';
 
-import { nanoid } from 'nanoid';
 import { notFound, redirect } from 'next/navigation';
 import { Session } from 'next-auth';
 
 import NotAuthorized from '@/app/not-authorized';
 import { auth } from '@/auth';
 import MainContent from '@/components/chat/main';
-import { AI, getUIStateFromAIState } from '@/lib/actions';
-import { ChatHistory } from '@/models/chat';
+import { AI } from '@/lib/actions';
+import { ChatHistory, blankAIState } from '@/models/chat';
 import { focuses, getFocusWithSubFocus } from '@/models/focus';
-import { llmModel } from '@/services/chatService';
 import { getChat } from '@/services/historyService';
 
 type HomePageProps = {
@@ -52,7 +50,7 @@ const ChatPage = async ({
   }
 
   return (
-    <AI initialAIState={chat} initialUIState={getUIStateFromAIState(chat)}>
+    <AI initialAIState={chat}>
       <MainContent />
     </AI>
   );
@@ -60,7 +58,6 @@ const ChatPage = async ({
 
 export default ChatPage;
 
-// TODO: move this into a server-only file
 const newChatSession = (
   session: Session,
   focusParam?: string,
@@ -69,14 +66,12 @@ const newChatSession = (
   const focus = getFocusWithSubFocus(focusParam, subFocusParam);
 
   const chat: ChatHistory = {
-    id: nanoid(),
-    title: 'Unknown Title',
-    messages: [],
+    ...blankAIState,
+    // id is '' in state until submitUserMessage() is called
     focus: focus ?? focuses[0],
-    llmModel: llmModel,
     user: session.user?.name ?? 'Unknown User',
     userId: session.user?.id ?? 'Unknown User',
-    timestamp: Date.now(),
   };
+
   return chat;
 };

--- a/src/app/share/[shareid]/page.tsx
+++ b/src/app/share/[shareid]/page.tsx
@@ -6,7 +6,7 @@ import { Session } from 'next-auth';
 
 import { auth } from '@/auth';
 import MainContent from '@/components/chat/main';
-import { AI, getUIStateFromAIState } from '@/lib/actions';
+import { AI } from '@/lib/actions';
 import { ChatHistory } from '@/models/chat';
 import { getSharedChat } from '@/services/historyService';
 
@@ -15,7 +15,6 @@ type SharedPageProps = {
     shareid: string;
   };
 };
-// TODO: loading animation when chatId changes
 const SharePage = async ({ params: { shareid } }: SharedPageProps) => {
   const session = (await auth()) as Session;
 
@@ -31,7 +30,7 @@ const SharePage = async ({ params: { shareid } }: SharedPageProps) => {
   }
 
   return (
-    <AI initialAIState={chat} initialUIState={getUIStateFromAIState(chat)}>
+    <AI initialAIState={chat}>
       <h5>Shared Chat</h5>
       <hr />
       <MainContent />

--- a/src/components/chat/answer/chatActions.tsx
+++ b/src/components/chat/answer/chatActions.tsx
@@ -14,11 +14,9 @@ import { GTagEvents } from '@/models/gtag';
 import FeedbackButtons from './feedbackButtons';
 import ShareModal from './shareModal';
 
-interface ChatActionsProps {
-  chatId: string;
-}
+interface ChatActionsProps {}
 
-const ChatActions: React.FC<ChatActionsProps> = ({ chatId }) => {
+const ChatActions: React.FC<ChatActionsProps> = ({}) => {
   const gtagEvent = useGtagEvent();
   const pathname = usePathname();
   const onSharedPage = pathname.includes('/share/');

--- a/src/components/chat/answer/wonkMessage.tsx
+++ b/src/components/chat/answer/wonkMessage.tsx
@@ -18,12 +18,10 @@ import { WonkPortrait } from '../rolePortrait';
 import ChatActions from './chatActions';
 
 export const WonkMessage = ({
-  chatId,
   content,
   isLoading,
   wonkThoughts,
 }: {
-  chatId: string; // will be '' until the chat is finished loading and saved
   content: string | StreamableValue<string>;
   isLoading: boolean;
   wonkThoughts: StreamableValue<string> | string;
@@ -110,7 +108,7 @@ export const WonkMessage = ({
           )}
         </div>
       </div>
-      {!isLoading && <ChatActions chatId={chatId} />}
+      {!isLoading && <ChatActions />}
     </div>
   );
 };

--- a/src/components/chat/answer/wonkMessage.tsx
+++ b/src/components/chat/answer/wonkMessage.tsx
@@ -23,7 +23,7 @@ export const WonkMessage = ({
   isLoading,
   wonkThoughts,
 }: {
-  chatId: string;
+  chatId: string; // will be '' until the chat is finished loading and saved
   content: string | StreamableValue<string>;
   isLoading: boolean;
   wonkThoughts: StreamableValue<string> | string;

--- a/src/lib/actions.tsx
+++ b/src/lib/actions.tsx
@@ -113,8 +113,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
 
     wonkThoughts.done('Search complete, getting your answer...'); // chatMessage component controls when to stop showing this message
 
-    // The `render()` creates a generated, streamable UI.
-    // this is the response itself. render returns a ReactNode (our textNode)
+    // start streaming the assistant response, this returns the ReactNode to render
     streamUI({
       model: openai(llmModel),
       initial: textNode,
@@ -163,7 +162,6 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
               },
             ],
           });
-          // TODO: use onSetAIState when it is no longer unstable
           (async () => {
             // save the chat to the db
             await saveChat(chatId, aiState.get().messages, focus);

--- a/src/lib/actions.tsx
+++ b/src/lib/actions.tsx
@@ -5,7 +5,7 @@ import {
   createStreamableValue,
   getAIState,
   getMutableAIState,
-  render,
+  streamUI,
 } from 'ai/rsc';
 import { nanoid } from 'nanoid';
 import { redirect } from 'next/navigation';
@@ -115,9 +115,8 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
 
     // The `render()` creates a generated, streamable UI.
     // this is the response itself. render returns a ReactNode (our textNode)
-    render({
-      model: llmModel,
-      provider: openai,
+    streamUI({
+      model: openai(llmModel),
       initial: textNode,
       messages: [
         ...aiState.get().messages.map((m: any) => ({

--- a/src/lib/actions.tsx
+++ b/src/lib/actions.tsx
@@ -59,10 +59,6 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
   // user message is added on client
   const chatWindowUI = createStreamableUI();
 
-  const chatId = nanoid(); // generate a new id on submit so we don't duplicate ids
-  const userMsgId = nanoid();
-  const wonkMsgId = nanoid();
-
   // and create the text stream for the response
   let textStream = createStreamableValue();
   // wonk thoughts for fun, but also to show that we can update at any point
@@ -72,7 +68,6 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
 
   let textNode: React.ReactNode = (
     <WonkMessage
-      chatId={chatId}
       content={textStream.value}
       wonkThoughts={wonkThoughts.value}
       isLoading={true}
@@ -97,7 +92,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
     const initialMessages: Message[] = [
       systemMessage, // system message with full document info
       {
-        id: userMsgId,
+        id: nanoid(), // new id for the user message
         role: 'user',
         content: userInput,
       },
@@ -106,7 +101,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
     // Update the AI state
     aiState.update({
       ...aiState.get(), // blank state
-      id: chatId, // where the new id is generated
+      id: nanoid(), // where the new id is generated
       focus, // focus from the user
       messages: [...aiState.get().messages, ...initialMessages],
     });
@@ -139,8 +134,6 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
 
           const finalNode = (
             <WonkMessage
-              chatId={chatId}
-              key={wonkMsgId}
               content={finalContent}
               isLoading={false}
               wonkThoughts={''}
@@ -156,7 +149,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
             messages: [
               ...aiState.get().messages,
               {
-                id: wonkMsgId,
+                id: nanoid(), // new id for the message
                 role: 'assistant',
                 content: finalContent,
               },
@@ -164,7 +157,7 @@ const submitUserMessage = async (userInput: string, focus: Focus) => {
           });
           (async () => {
             // save the chat to the db
-            await saveChat(chatId, aiState.get().messages, focus);
+            await saveChat(aiState.get().id, aiState.get().messages, focus);
           })();
         } else {
           textStream.update(delta);
@@ -253,7 +246,6 @@ export const AI = createAI<ChatHistory, UIState, WonkActions>({
             </>
           ) : (
             <WonkMessage
-              chatId={aiState.id}
               content={message.content}
               isLoading={false}
               wonkThoughts={''}

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -1,6 +1,8 @@
 import { Message } from 'ai';
 
-import { Focus } from './focus';
+import { llmModel } from '@/services/chatService';
+
+import { Focus, focuses } from './focus';
 
 export type ChatHistory = {
   id: string;
@@ -13,6 +15,19 @@ export type ChatHistory = {
   reaction?: Feedback;
   timestamp: number;
   shareId?: string;
+};
+
+export const blankAIState: ChatHistory = {
+  id: '', // don't use nanoid() here so we make sure to generate a new id when we create a new chat
+  title: '',
+  messages: [],
+  focus: focuses[0],
+  llmModel: llmModel,
+  user: '',
+  userId: '',
+  reaction: undefined,
+  timestamp: Date.now(),
+  shareId: undefined,
 };
 
 export type Feedback = 'thumbs_up' | 'thumbs_down';


### PR DESCRIPTION
❗ **requires npm install** ❗ 

updates ai package to 3.0 -> 3.1 
uses `onGetUIState` now that it's not unstable
`render()` was marked deprecated so i updated it to `streamUI()`, which wants model to be a `@ai-sdk/openai` type so i changed to using that so we don't have to fight typings. returns the same array of embeddings (but @srkirkland double check my work please) 
i chose not to use `onSetAIState` because it's called for every `aiState.done()` and `aiState.update()` without a clear way to distinguish where it's being called 

also closes #56 by generating the chat id on `submitUserMessage` instead of on `page.tsx` 