### PR TITLE
history list height

### DIFF
--- a/src/app/styles/_regions.scss
+++ b/src/app/styles/_regions.scss
@@ -69,7 +69,7 @@ img.chat-portrait {
         color:$secondary-font;
     }
     .history-list {
-        max-height:700px;
+        max-height:80vh;
         overflow-y: scroll;
         width: calc(100% + 15px);
         padding:0;

--- a/src/app/styles/_regions.scss
+++ b/src/app/styles/_regions.scss
@@ -69,10 +69,13 @@ img.chat-portrait {
         color:$secondary-font;
     }
     .history-list {
-        max-height:80vh;
+        max-height:75vh;
         overflow-y: scroll;
         width: calc(100% + 15px);
         padding:0;
+        @include breakpoint(lg) {
+                max-height:80vh;
+            }
         .history-list-group-item {
             list-style: none;
             overflow: hidden;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved responsiveness of the history list by setting its maximum height to 80% of the viewport height, ensuring better adaptation to varying screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->