### PR TITLE
use default profile image if its not current user

### DIFF
--- a/src/components/chat/userMessage.tsx
+++ b/src/components/chat/userMessage.tsx
@@ -15,7 +15,7 @@ export const UserMessage = ({
     <div className='row mb-3'>
       <div className='col-2 col-sm-1 mb-2'>
         <WonkyErrorBoundary>
-          <UserPortrait />
+          <UserPortrait for={user} />
         </WonkyErrorBoundary>
       </div>
       <div className='col-10'>

--- a/src/components/chat/userPortrait.tsx
+++ b/src/components/chat/userPortrait.tsx
@@ -4,10 +4,22 @@ import React from 'react';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 
-export const UserPortrait = React.memo(function UserPortrait() {
+interface UserPortraitProps {
+  for?: string;
+}
+
+export const UserPortrait = React.memo(function UserPortrait(
+  props: UserPortraitProps
+) {
   const session = useSession();
 
-  const userImage = session?.data?.user?.image || '/media/ph-profile.svg';
+  let userImage = '/media/ph-profile.svg';
+
+  // if the we are showing the user's portrait, use the user's image if it exists
+  if (session?.data?.user?.name === props.for && session?.data?.user?.image) {
+    userImage = session?.data?.user?.image;
+  }
+
   return (
     <div className='role-portrait'>
       <Image


### PR DESCRIPTION
pass along name of user that the image is for.  if it's for the currently logged in user, get their profile.  otherwise just use default, since we can't get other user profile pics anyway.

closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `UserPortrait` component to conditionally display user images based on specific user data.
  - Added a new interface for improved handling of user-related properties.

- **Improvements**
  - Increased flexibility of user image rendering in the `UserMessage` and `UserPortrait` components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->