### PR TITLE
include group in chat history so we don't flash

### DIFF
--- a/web/src/components/chatHistory/chatHistoryList.tsx
+++ b/web/src/components/chatHistory/chatHistoryList.tsx
@@ -56,7 +56,9 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = ({ chats }) => {
           >
             <div className='row'>
               <div className='col-11'>
-                <Link href={`/chat/${chat.id}`}>{chat.title}</Link>
+                <Link href={`/${chat.group}/chat/${chat.id}`}>
+                  {chat.title}
+                </Link>
               </div>
               <DeleteChatButton
                 chatId={chat.id}

--- a/web/src/services/historyService.ts
+++ b/web/src/services/historyService.ts
@@ -29,6 +29,7 @@ const POLICY_ASSISTANT_SLUG = 'policywonk'; // just hardcode since we have only 
 export type ChatHistoryTitleEntry = {
   id: string;
   title: string;
+  group: string;
   timestamp: Date;
 };
 
@@ -64,6 +65,7 @@ export const getChatHistoryForGroup = async (
     select: {
       id: true,
       title: true,
+      group: true,
       timestamp: true,
     },
   });
@@ -92,6 +94,7 @@ export const getChatHistory = async (): Promise<
     },
     select: {
       id: true,
+      group: true,
       title: true,
       timestamp: true,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat history links now include the group in their URL paths, improving navigation and context when accessing individual chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->