### PR TITLE
use chunks when sending embeddings to azure

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,4 @@ ELASTIC_INDEX=pw-dev
 
 LLM_API_KEY="" # OpenAI API key
 LLM_EMBEDDING_MODEL="text-embedding-3-small" # -large in prod
+LLM_EMBEDDINGS_CHUNK_SIZE="64" # batch size for embeddings requests (lower if you hit token-per-request limits)

--- a/backend/background/util/elastic.py
+++ b/backend/background/util/elastic.py
@@ -22,6 +22,7 @@ ELASTIC_INDEX = os.getenv("ELASTIC_INDEX", "vectorstore_test")
 # Setup for Embeddings
 LLM_API_KEY = os.getenv("LLM_API_KEY", "")
 LLM_EMBEDDING_MODEL = os.getenv("LLM_EMBEDDING_MODEL", "text-embedding-3-small")
+LLM_EMBEDDINGS_CHUNK_SIZE = int(os.getenv("LLM_EMBEDDINGS_CHUNK_SIZE", "64"))
 
 USE_DEV_SETTINGS = os.getenv("USE_DEV_SETTINGS", "false").lower() == "true"
 FAKE_EMBEDDINGS_SIZE = int(os.getenv("FAKE_EMBEDDINGS_SIZE", "1536"))
@@ -54,11 +55,13 @@ if USE_AZURE_EMBEDDINGS:
         azure_endpoint=AZURE_OPENAI_ENDPOINT,
         api_key=SecretStr(AZURE_OPENAI_API_KEY),
         azure_deployment=AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT,
+        chunk_size=LLM_EMBEDDINGS_CHUNK_SIZE,
     )
 elif USE_OPENAI_EMBEDDINGS:
     embeddings = OpenAIEmbeddings(
         model=LLM_EMBEDDING_MODEL,
         api_key=SecretStr(LLM_API_KEY),
+        chunk_size=LLM_EMBEDDINGS_CHUNK_SIZE,
     )
 else:
     if not USE_DEV_SETTINGS and not (LLM_API_KEY and LLM_EMBEDDING_MODEL):

--- a/backend/background/vectorize.py
+++ b/backend/background/vectorize.py
@@ -68,7 +68,8 @@ def vectorize_document(session: Session, source: Source, document_details: Docum
     delete_by_url(source.id, document_details.url)
 
     # add the new vectors for the doc
-    # should be ok without batching since we are doing per doc
+    # We rely on the embeddings client's internal batching (see LLM_EMBEDDINGS_CHUNK_SIZE)
+    # to avoid exceeding provider "tokens per request" limits on large documents.
     store.add_documents(chunks)
 
     # 3. remove any existing content related to the doc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `LLM_EMBEDDINGS_CHUNK_SIZE` environment variable to allow configuration of embeddings request batch processing size. This new configuration parameter enables users to customize how embeddings requests are processed in batches, providing more granular control over embeddings handling and batch processing behavior based on specific deployment requirements. Default value is 64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->